### PR TITLE
fix: replace deprecated `PyObject` with `Py<PyAny>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "dockerfile-analyzer"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "docker-image",
  "parse-dockerfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dockerfile-analyzer"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/models.rs
+++ b/src/models.rs
@@ -26,7 +26,7 @@ impl InstructionStats {
         )
     }
 
-    fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    fn to_dict(&self, py: Python) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         dict.set_item("total_count", self.total_count)?;
         dict.set_item("by_type", &self.by_type)?;
@@ -64,7 +64,7 @@ impl ImageComponents {
         )
     }
 
-    fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    fn to_dict(&self, py: Python) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         dict.set_item("registry", &self.registry)?;
         dict.set_item("name", &self.name)?;
@@ -102,7 +102,7 @@ impl Image {
         )
     }
 
-    fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    fn to_dict(&self, py: Python) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         dict.set_item("full", &self.full)?;
 
@@ -148,7 +148,7 @@ impl MultistageAnalysis {
         )
     }
 
-    fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    fn to_dict(&self, py: Python) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         dict.set_item("is_multistage", self.is_multistage)?;
         dict.set_item(
@@ -215,12 +215,12 @@ impl Analysis {
         )
     }
 
-    fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    fn to_dict(&self, py: Python) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         dict.set_item("num_stages", self.num_stages)?;
 
         // Convert Vec<Image> to Vec<PyObject>
-        let images: PyResult<Vec<PyObject>> =
+        let images: PyResult<Vec<Py<PyAny>>> =
             self.images.iter().map(|img| img.to_dict(py)).collect();
         dict.set_item("images", images?)?;
 
@@ -259,7 +259,7 @@ impl KeyValueInstr {
         )
     }
 
-    fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    fn to_dict(&self, py: Python) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);
         dict.set_item("args", &self.args)?;
         dict.set_item("labels", &self.labels)?;


### PR DESCRIPTION
- pyo3 v0.26.0 deprecated the `PyObject` type alias: https://pyo3.rs/v0.26.0/migration.html#deprecation-of-pyobject-type-alias
- Replacing this deprecated type with `Py<PyAny>` per the migration guide.